### PR TITLE
feat: add support for ghcr images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,15 @@ on:
         required: false
         type: boolean
         default: true
+      enable_ghcr:
+        description: 'Enable push to GitHub Container Registry (ghcr.io)'
+        required: false
+        type: boolean
+        default: false
+      ghcr_repository_url:
+        description: 'Repository URL for GHCR, i.e. registry + owner (e.g. ghcr.io/your-org). Must be lowercase; it is lowercased automatically.'
+        required: false
+        type: string
       aws_ecr_region:
         description: 'AWS Public ECR region'
         required: false
@@ -141,6 +150,9 @@ on:
       image_build_secrets:
         description: 'Newline-delimited KEY=VALUE build args that contain secrets. Appended to image_build_args (which cannot carry secrets since the caller with: block has no secrets context).'
         required: false
+      ghcr_token:
+        description: 'Token used to push to GHCR. Optional: defaults to the caller-provided GITHUB_TOKEN (needs packages: write permission). Provide a PAT only when pushing to an owner different from the calling repository.'
+        required: false
 
 # Jobs
 jobs:
@@ -153,6 +165,7 @@ jobs:
     env:
       JFROG_IMAGE_URL: ${{ inputs.artifactory_repository_url }}/${{ inputs.image_artifact_name }}
       ECR_IMAGE_URL: ${{ inputs.ecr_repository_url }}/${{ inputs.image_artifact_name }}
+      GHCR_IMAGE_URL: ${{ inputs.ghcr_repository_url }}/${{ inputs.image_artifact_name }}
     steps:
       - name: Free Disk Space (Ubuntu)
         if: ${{ inputs.free_disk_space }}
@@ -175,8 +188,8 @@ jobs:
 
       - name: Validate registry configuration
         run: |
-          if [ "${{ inputs.enable_jfrog }}" != "true" ] && [ "${{ inputs.enable_public_ecr }}" != "true" ]; then
-            echo "Error: At least one registry must be enabled (enable_jfrog or enable_public_ecr)"
+          if [ "${{ inputs.enable_jfrog }}" != "true" ] && [ "${{ inputs.enable_public_ecr }}" != "true" ] && [ "${{ inputs.enable_ghcr }}" != "true" ]; then
+            echo "Error: At least one registry must be enabled (enable_jfrog, enable_public_ecr or enable_ghcr)"
             exit 1
           fi
 
@@ -190,6 +203,13 @@ jobs:
           if [ "${{ inputs.enable_public_ecr }}" == "true" ]; then
             if [ -z "${{ inputs.ecr_repository_url }}" ]; then
               echo "Error: ecr_repository_url is required when enable_public_ecr is true"
+              exit 1
+            fi
+          fi
+
+          if [ "${{ inputs.enable_ghcr }}" == "true" ]; then
+            if [ -z "${{ inputs.ghcr_repository_url }}" ]; then
+              echo "Error: ghcr_repository_url is required when enable_ghcr is true"
               exit 1
             fi
           fi
@@ -220,6 +240,14 @@ jobs:
         run: |
           aws ecr-public get-login-password --region ${{ inputs.aws_ecr_region }} | docker login --username AWS --password-stdin public.ecr.aws
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ inputs.enable_ghcr }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ghcr_token || github.token }}
+
       - name: Build image for scanning
         uses: docker/build-push-action@v6
         if: ${{ inputs.enable_scan }}
@@ -249,10 +277,19 @@ jobs:
         env:
           JFROG_IMAGE_URL: ${{ env.JFROG_IMAGE_URL }}
           ECR_IMAGE_URL: ${{ env.ECR_IMAGE_URL }}
+          GHCR_IMAGE_URL: ${{ env.GHCR_IMAGE_URL }}
           ENABLE_JFROG: ${{ inputs.enable_jfrog }}
           ENABLE_ECR: ${{ inputs.enable_public_ecr }}
+          ENABLE_GHCR: ${{ inputs.enable_ghcr }}
         run: |
           TAGS=()
+
+          # GHCR requires the image reference to be lowercase; normalize it and
+          # propagate the lowercased value to later steps (cache, SBOM).
+          if [ "$ENABLE_GHCR" == "true" ]; then
+            GHCR_IMAGE_URL="${GHCR_IMAGE_URL,,}"
+            echo "GHCR_IMAGE_URL=$GHCR_IMAGE_URL" >> "$GITHUB_ENV"
+          fi
 
           # Add primary tags for enabled registries
           if [ "$ENABLE_JFROG" == "true" ]; then
@@ -263,6 +300,11 @@ jobs:
           if [ "$ENABLE_ECR" == "true" ]; then
             echo "Adding ECR tag: $ECR_IMAGE_URL:${{ inputs.image_tag }}"
             TAGS+=("$ECR_IMAGE_URL:${{ inputs.image_tag }}")
+          fi
+
+          if [ "$ENABLE_GHCR" == "true" ]; then
+            echo "Adding GHCR tag: $GHCR_IMAGE_URL:${{ inputs.image_tag }}"
+            TAGS+=("$GHCR_IMAGE_URL:${{ inputs.image_tag }}")
           fi
 
           # Process extra tags if provided
@@ -281,6 +323,10 @@ jobs:
                 if [ "$ENABLE_ECR" == "true" ]; then
                   echo "Adding extra ECR tag: $ECR_IMAGE_URL:$tag"
                   TAGS+=("$ECR_IMAGE_URL:$tag")
+                fi
+                if [ "$ENABLE_GHCR" == "true" ]; then
+                  echo "Adding extra GHCR tag: $GHCR_IMAGE_URL:$tag"
+                  TAGS+=("$GHCR_IMAGE_URL:$tag")
                 fi
               fi
             done <<< "${{ inputs.extra_image_tag }}"
@@ -302,9 +348,12 @@ jobs:
           if [ "${{ inputs.enable_jfrog }}" == "true" ]; then
             echo "cache_ref=${{ env.JFROG_IMAGE_URL }}:buildcache" >> $GITHUB_OUTPUT
             echo "Using JFrog for build cache"
-          else
+          elif [ "${{ inputs.enable_public_ecr }}" == "true" ]; then
             echo "cache_ref=${{ env.ECR_IMAGE_URL }}:buildcache" >> $GITHUB_OUTPUT
             echo "Using ECR for build cache"
+          else
+            echo "cache_ref=${{ env.GHCR_IMAGE_URL }}:buildcache" >> $GITHUB_OUTPUT
+            echo "Using GHCR for build cache"
           fi
 
       - name: Build and push image
@@ -338,6 +387,7 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
           ENABLE_JFROG: ${{ inputs.enable_jfrog }}
+          ENABLE_ECR: ${{ inputs.enable_public_ecr }}
           SYFT: ${{ steps.syft.outputs.cmd }}
           SBOM_ARTIFACT_NAME: ${{ inputs.sbom_artifact_name }}
         run: |
@@ -355,8 +405,10 @@ jobs:
           # single SBOM is generated from whichever registry is enabled.
           if [ "$ENABLE_JFROG" == "true" ]; then
             REF="${JFROG_IMAGE_URL}@${DIGEST}"
-          else
+          elif [ "$ENABLE_ECR" == "true" ]; then
             REF="${ECR_IMAGE_URL}@${DIGEST}"
+          else
+            REF="${GHCR_IMAGE_URL}@${DIGEST}"
           fi
 
           # Build a filesystem-safe SBOM file name from the artifact name and tag.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
 
 | Workflow file                     | Name                                          | Purpose                                                              |
 | --------------------------------- | --------------------------------------------- | ------------------------------------------------------------------- |
-| `build.yml`                       | Build and push container images to Artifactory | Build a multi-platform image and push to JFrog Artifactory and/or AWS Public ECR |
+| `build.yml`                       | Build and push container images to Artifactory | Build a multi-platform image and push to JFrog Artifactory, AWS Public ECR and/or GitHub Container Registry (GHCR) |
 | `build-and-push-soci-index.yml`   | Build and push SOCI index                     | Convert an existing pushed image into a SOCI index for lazy pulls   |
 | `mirror-with-soci.yml`            | Mirror x86 image with SOCI index              | Mirror an `amd64` image from a source registry and push a SOCI index |
 | `update-grype-report.yml`         | Update Grype Ignore File                      | Scan an image with Grype and open a PR updating the ignore list     |
@@ -37,8 +37,8 @@ jobs:
 
 ### `build.yml` — Build and push container images to Artifactory
 
-Builds a multi-platform Docker image and pushes it to JFrog Artifactory and/or AWS Public
-ECR. Optionally frees runner disk space, scans the `amd64` image with Anchore Grype before
+Builds a multi-platform Docker image and pushes it to JFrog Artifactory, AWS Public
+ECR and/or GitHub Container Registry (GHCR). Optionally frees runner disk space, scans the `amd64` image with Anchore Grype before
 pushing, applies extra tags, and emits provenance attestation. Can also generate an SPDX
 SBOM for the pushed image (using [Syft](https://github.com/anchore/syft)) and upload it as a
 workflow artifact so callers can attach it to a release. Uses a registry-based build cache.
@@ -76,6 +76,8 @@ jobs:
 | `enable_public_ecr`                  | Enable push to AWS Public ECR                                         | boolean | false    | `false`                  |
 | `ecr_repository_url`                 | Repository URL for AWS Public ECR (e.g. `public.ecr.aws/alias/repo`)  | string  | false    |                          |
 | `enable_jfrog`                       | Enable push to JFrog Artifactory                                      | boolean | false    | `true`                   |
+| `enable_ghcr`                        | Enable push to GitHub Container Registry (`ghcr.io`)                  | boolean | false    | `false`                  |
+| `ghcr_repository_url`                | GHCR registry + owner (e.g. `ghcr.io/your-org`); lowercased automatically | string  | false    |                          |
 | `aws_ecr_region`                     | AWS Public ECR region                                                 | string  | false    | `us-east-1`              |
 | `image_scan_severity_cutoff`         | Severity cutoff for image scanning                                    | string  | false    | `high`                   |
 | `dockerfile_path`                    | Path to the Dockerfile                                                | string  | false    | `Dockerfile`             |
@@ -95,6 +97,7 @@ jobs:
 | `artifactory_username` | Username for JFrog Artifactory                          | Required if `enable_jfrog`  |
 | `artifactory_password` | Password for JFrog Artifactory                          | Required if `enable_jfrog`  |
 | `ecr_role_arn`         | Role ARN to pull/push images to AWS Public ECR          | Required if `enable_public_ecr` |
+| `ghcr_token`           | Token to push to GHCR. Defaults to the caller's `GITHUB_TOKEN`; provide a PAT only to push to a different owner | Optional (with `enable_ghcr`) |
 
 **Outputs**
 
@@ -141,6 +144,42 @@ jobs:
         with:
           files: sbom/${{ needs.build.outputs.sbom_file_name }}
 ```
+
+**GHCR (GitHub Container Registry)**
+
+Push to `ghcr.io` by setting `enable_ghcr: true` and `ghcr_repository_url` to your registry +
+owner. In the common case (pushing to a package owned by the same org as the calling repo) no
+secret is needed — the workflow uses the caller's `GITHUB_TOKEN`. **The calling job must grant
+`packages: write`**, because a reusable workflow inherits its token permissions from the caller:
+
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: read
+      packages: write        # required for GHCR push via GITHUB_TOKEN
+    uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
+    with:
+      enable_jfrog: false
+      enable_ghcr: true
+      ghcr_repository_url: ghcr.io/${{ github.repository_owner }}
+      image_artifact_name: mlfoundry-server
+      image_tag: ${{ github.sha }}
+```
+
+Notes:
+
+- GHCR requires the full image reference to be lowercase; `ghcr_repository_url` is lowercased
+  automatically, so `github.repository_owner` values with capitals are fine.
+- To push to a **different** owner than the calling repo, `GITHUB_TOKEN` is not enough — pass a
+  PAT with `write:packages` as the `ghcr_token` secret.
+- GHCR can be enabled alongside JFrog and/or ECR; the image is built once and pushed to all
+  enabled registries.
+- **Newly created GHCR packages are private by default.** To make an image pullable without
+  authentication, change its visibility to public manually after the first push: open the
+  package at `https://github.com/orgs/<owner>/packages` (or the user's Packages tab) →
+  **Package settings** → **Change visibility** → **Public**. This only needs to be done once per
+  package.
 
 ---
 


### PR DESCRIPTION
Signed-off-by: Raman Tehlan <ramantehlan@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only additive registry option with defaults unchanged; main caller pitfall is missing `packages: write` or wrong token for cross-owner pushes.
> 
> **Overview**
> Extends the reusable **`build.yml`** workflow so callers can push the same built image to **GitHub Container Registry** alongside JFrog and/or AWS Public ECR.
> 
> New inputs **`enable_ghcr`** (default off) and **`ghcr_repository_url`**, plus optional **`ghcr_token`** (falls back to the caller’s `GITHUB_TOKEN`). Validation now requires at least one of JFrog, ECR, or GHCR. When GHCR is on, the workflow logs in to `ghcr.io`, lowercases the image reference for GHCR rules, and includes GHCR in primary and extra tags. **Build cache** and **SBOM** registry selection is updated from a JFrog-or-ECR split to JFrog → ECR → GHCR priority so GHCR-only builds still get cache and SBOM.
> 
> **README** documents the new inputs/secrets, a sample job with `packages: write`, PAT vs `GITHUB_TOKEN`, and default private package visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b4d2afa674aec7fc294cd003662f945a5e5caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->