### PR TITLE
feat: add signed support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,11 @@ on:
         required: false
         type: string
         default: 'sbom'
+      enable_sign:
+        description: 'Keyless (Sigstore) sign the pushed image by digest with cosign (signature stored in the registry and emitted as .sig/.pem/.payload files) and sign the SPDX SBOM to produce a .sigstore.json bundle. All signature files are uploaded in the SBOM workflow artifact for attaching to a GitHub release (OpenSSF Signed-Releases). Requires the calling job to grant id-token: write. Signing the SBOM requires enable_sbom to be true.'
+        required: false
+        type: boolean
+        default: false
       checkout_submodules:
         description: 'Whether to checkout git submodules: "true", "recursive", or "false"'
         required: false
@@ -134,6 +139,15 @@ on:
       sbom_file_name:
         description: 'File name of the SPDX SBOM inside the uploaded artifact. Empty when enable_sbom is false.'
         value: ${{ jobs.build.outputs.sbom_file_name }}
+      sbom_signature_file_name:
+        description: 'File name of the keyless Sigstore bundle (*.sigstore.json) signing the SBOM, inside the uploaded artifact. Empty unless enable_sign and enable_sbom are both true.'
+        value: ${{ jobs.build.outputs.sbom_signature_file_name }}
+      image_signature_file_name:
+        description: 'File name of the raw cosign image signature (*.sig) inside the uploaded artifact. Empty when enable_sign is false.'
+        value: ${{ jobs.build.outputs.image_signature_file_name }}
+      image_certificate_file_name:
+        description: 'File name of the Fulcio signing certificate (*.pem) for the image signature, inside the uploaded artifact. Empty when enable_sign is false.'
+        value: ${{ jobs.build.outputs.image_certificate_file_name }}
     secrets:
       artifactory_username:
         description: 'Username for JFrog Artifactory. Required if enable_jfrog is true'
@@ -160,8 +174,11 @@ jobs:
     name: Build and Push Image to Repository
     runs-on: ubuntu-latest
     outputs:
-      sbom_artifact_name: ${{ steps.sbom.outputs.artifact_name }}
+      sbom_artifact_name: ${{ (inputs.enable_sbom || inputs.enable_sign) && inputs.sbom_artifact_name || '' }}
       sbom_file_name: ${{ steps.sbom.outputs.file }}
+      sbom_signature_file_name: ${{ steps.sign_sbom.outputs.signature_file }}
+      image_signature_file_name: ${{ steps.sign_image.outputs.signature_file }}
+      image_certificate_file_name: ${{ steps.sign_image.outputs.certificate_file }}
     env:
       JFROG_IMAGE_URL: ${{ inputs.artifactory_repository_url }}/${{ inputs.image_artifact_name }}
       ECR_IMAGE_URL: ${{ inputs.ecr_repository_url }}/${{ inputs.image_artifact_name }}
@@ -376,6 +393,68 @@ jobs:
         run: |
           echo "Image digest: ${{ steps.build.outputs.digest }}"
 
+      - name: Install cosign
+        if: ${{ inputs.enable_sign }}
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image(s) with cosign (keyless)
+        id: sign_image
+        if: ${{ inputs.enable_sign }}
+        env:
+          COSIGN_YES: 'true'
+          DIGEST: ${{ steps.build.outputs.digest }}
+          ENABLE_JFROG: ${{ inputs.enable_jfrog }}
+          ENABLE_ECR: ${{ inputs.enable_public_ecr }}
+          ENABLE_GHCR: ${{ inputs.enable_ghcr }}
+          ENABLE_SBOM: ${{ inputs.enable_sbom }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DIGEST" ]; then
+            echo "Error: image digest is empty, cannot sign" >&2
+            exit 1
+          fi
+
+          if [ "$ENABLE_SBOM" != "true" ]; then
+            echo "::notice::enable_sign is on but enable_sbom is off; no SBOM signature (*.sigstore.json) will be produced. Enable enable_sbom for the strongest OpenSSF Signed-Releases result."
+          fi
+
+          mkdir -p release-artifacts
+
+          # Filesystem-safe base name shared by all release signature files.
+          BASE="${{ inputs.image_artifact_name }}-${{ inputs.image_tag }}"
+          BASE="${BASE//\//-}"
+
+          # Collect every enabled registry ref for the pushed digest. The image
+          # content is identical across registries, so one set of output files
+          # (from the first ref) represents all of them.
+          REFS=()
+          if [ "$ENABLE_JFROG" == "true" ]; then REFS+=("${JFROG_IMAGE_URL}@${DIGEST}"); fi
+          if [ "$ENABLE_ECR" == "true" ]; then REFS+=("${ECR_IMAGE_URL}@${DIGEST}"); fi
+          if [ "$ENABLE_GHCR" == "true" ]; then REFS+=("${GHCR_IMAGE_URL}@${DIGEST}"); fi
+
+          SIG_FILE="${BASE}.sig"
+          CERT_FILE="${BASE}.pem"
+          PAYLOAD_FILE="${BASE}.payload"
+
+          first=1
+          for ref in "${REFS[@]}"; do
+            if [ "$first" == "1" ]; then
+              echo "Signing ${ref} (emitting release files)"
+              cosign sign --yes \
+                --output-signature "release-artifacts/${SIG_FILE}" \
+                --output-certificate "release-artifacts/${CERT_FILE}" \
+                --output-payload "release-artifacts/${PAYLOAD_FILE}" \
+                "${ref}"
+              first=0
+            else
+              echo "Signing ${ref}"
+              cosign sign --yes "${ref}"
+            fi
+          done
+
+          echo "signature_file=${SIG_FILE}" >> "$GITHUB_OUTPUT"
+          echo "certificate_file=${CERT_FILE}" >> "$GITHUB_OUTPUT"
+
       - name: Install Syft
         id: syft
         if: ${{ inputs.enable_sbom }}
@@ -389,7 +468,6 @@ jobs:
           ENABLE_JFROG: ${{ inputs.enable_jfrog }}
           ENABLE_ECR: ${{ inputs.enable_public_ecr }}
           SYFT: ${{ steps.syft.outputs.cmd }}
-          SBOM_ARTIFACT_NAME: ${{ inputs.sbom_artifact_name }}
         run: |
           set -euo pipefail
           if [ -z "$DIGEST" ]; then
@@ -400,6 +478,8 @@ jobs:
             echo "Error: Syft command path is empty, cannot generate SBOM" >&2
             exit 1
           fi
+
+          mkdir -p release-artifacts
 
           # The image content is identical across registries (same digest), so a
           # single SBOM is generated from whichever registry is enabled.
@@ -415,16 +495,39 @@ jobs:
           SBOM_FILE="${{ inputs.image_artifact_name }}-${{ inputs.image_tag }}.spdx.json"
           SBOM_FILE="${SBOM_FILE//\//-}"
 
-          echo "Generating SPDX SBOM for ${REF} -> ${SBOM_FILE}"
-          "$SYFT" scan "registry:${REF}" -o spdx-json="${SBOM_FILE}"
+          echo "Generating SPDX SBOM for ${REF} -> release-artifacts/${SBOM_FILE}"
+          "$SYFT" scan "registry:${REF}" -o spdx-json="release-artifacts/${SBOM_FILE}"
 
           echo "file=${SBOM_FILE}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name=${SBOM_ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload SBOM artifact
-        if: ${{ inputs.enable_sbom }}
+      - name: Sign SBOM with cosign (keyless)
+        id: sign_sbom
+        if: ${{ inputs.enable_sign && inputs.enable_sbom }}
+        env:
+          COSIGN_YES: 'true'
+          SBOM_FILE: ${{ steps.sbom.outputs.file }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SBOM_FILE" ]; then
+            echo "Error: SBOM file name is empty, cannot sign SBOM" >&2
+            exit 1
+          fi
+
+          # cosign sign-blob --bundle emits a self-contained Sigstore bundle
+          # (signature + Fulcio cert + Rekor proof). Named *.sigstore.json so it
+          # is recognised by the OpenSSF Signed-Releases check as a release asset.
+          SIG_FILE="${SBOM_FILE}.sigstore.json"
+          echo "Signing SBOM release-artifacts/${SBOM_FILE} -> release-artifacts/${SIG_FILE}"
+          cosign sign-blob --yes \
+            --bundle "release-artifacts/${SIG_FILE}" \
+            "release-artifacts/${SBOM_FILE}"
+
+          echo "signature_file=${SIG_FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload SBOM and signature artifact
+        if: ${{ inputs.enable_sbom || inputs.enable_sign }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.sbom.outputs.artifact_name }}
-          path: ${{ steps.sbom.outputs.file }}
+          name: ${{ inputs.sbom_artifact_name }}
+          path: release-artifacts
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ jobs:
 Builds a multi-platform Docker image and pushes it to JFrog Artifactory, AWS Public
 ECR and/or GitHub Container Registry (GHCR). Optionally frees runner disk space, scans the `amd64` image with Anchore Grype before
 pushing, applies extra tags, and emits provenance attestation. Can also generate an SPDX
-SBOM for the pushed image (using [Syft](https://github.com/anchore/syft)) and upload it as a
-workflow artifact so callers can attach it to a release. Uses a registry-based build cache.
+SBOM for the pushed image (using [Syft](https://github.com/anchore/syft)) and keyless-sign the
+image and SBOM with [cosign](https://github.com/sigstore/cosign), uploading everything as a single
+workflow artifact so callers can attach it to a release (e.g. for the OpenSSF Signed-Releases
+check). Uses a registry-based build cache.
 
 **Usage**
 
@@ -88,7 +90,8 @@ jobs:
 | `free_disk_space_large_packages`     | Free disk space used by large packages                                | boolean | false    | `false`                  |
 | `enable_provenance`                  | Enable provenance attestation for supply-chain security               | boolean | false    | `false`                  |
 | `enable_sbom`                        | Generate an SPDX SBOM for the pushed image (Syft) and upload it as a workflow artifact | boolean | false | `false`         |
-| `sbom_artifact_name`                 | Name of the uploaded workflow artifact containing the SBOM            | string  | false    | `sbom`                   |
+| `sbom_artifact_name`                 | Name of the uploaded workflow artifact containing the SBOM and signatures | string  | false    | `sbom`                   |
+| `enable_sign`                        | Keyless (Sigstore) sign the image and SBOM with cosign; uploads `.sig`/`.pem`/`.payload`/`.sigstore.json` in the SBOM artifact. Requires the calling job to grant `id-token: write`; SBOM signing needs `enable_sbom: true` | boolean | false | `false` |
 
 **Secrets**
 
@@ -103,26 +106,53 @@ jobs:
 
 | Name                 | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
-| `sbom_artifact_name` | Name of the uploaded workflow artifact containing the SPDX SBOM (empty when `enable_sbom` is false) |
-| `sbom_file_name`     | File name of the SPDX SBOM inside the uploaded artifact (empty when `enable_sbom` is false)      |
+| `sbom_artifact_name`          | Name of the uploaded workflow artifact containing the SBOM and any signatures (empty unless `enable_sbom` or `enable_sign`) |
+| `sbom_file_name`              | File name of the SPDX SBOM inside the uploaded artifact (empty when `enable_sbom` is false)      |
+| `sbom_signature_file_name`    | File name of the SBOM's Sigstore bundle `*.sigstore.json` (empty unless `enable_sign` and `enable_sbom`) |
+| `image_signature_file_name`   | File name of the raw cosign image signature `*.sig` (empty when `enable_sign` is false)          |
+| `image_certificate_file_name` | File name of the Fulcio signing certificate `*.pem` for the image signature (empty when `enable_sign` is false) |
 
 **SBOM (Syft)**
 
 When `enable_sbom` is `true`, an SPDX-JSON SBOM is generated for the pushed image (scanned by
 digest with [Syft](https://github.com/anchore/syft)) and uploaded as a workflow artifact. The
-caller can download that artifact with `actions/download-artifact` and attach it to a release —
-for example to satisfy OpenSSF compliance requirements.
+caller can download that artifact with `actions/download-artifact` and attach it to a release.
+
+**Signing (keyless / Sigstore)**
+
+When `enable_sign` is `true`, the workflow uses keyless [cosign](https://github.com/sigstore/cosign)
+(Sigstore) — no long-lived keys, trust is anchored to the workflow's GitHub OIDC identity via
+Fulcio and the Rekor transparency log. It does two things:
+
+- **Image**: `cosign sign` the pushed image by digest in every enabled registry (verifiable with
+  `cosign verify`), and also emits raw signature files for the release: `<base>.sig`,
+  `<base>.pem` (the Fulcio certificate) and `<base>.payload` (the signed payload, so the `.sig` is
+  offline-verifiable).
+- **SBOM** (requires `enable_sbom: true`): `cosign sign-blob --bundle` the SBOM, producing a
+  self-contained `<base>.spdx.json.sigstore.json` bundle.
+
+All of these — the SBOM plus every signature file — are uploaded together in the single artifact
+named by `sbom_artifact_name`, so the caller downloads once and attaches them all to the release.
+The `*.sigstore.json` and `*.sig` filenames are what the **OpenSSF Signed-Releases** check looks
+for in release assets (score 8).
+
+> The calling `build` job **must** grant `permissions: id-token: write` for keyless signing to work
+> (plus `packages: write` if `enable_ghcr` is used). `contents: read` is the default.
 
 ```yaml
 jobs:
   build:
     uses: truefoundry/github-workflows-public/.github/workflows/build.yml@main
+    permissions:
+      contents: read
+      id-token: write        # required for keyless cosign signing
     with:
       artifactory_registry_url: tfy.jfrog.io
       artifactory_repository_url: tfy.jfrog.io/tfy-images
       image_artifact_name: mlfoundry-server
       image_tag: ${{ github.ref_name }}
       enable_sbom: true
+      enable_sign: true
     secrets:
       artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
       artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -133,16 +163,40 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download SBOM
+      - name: Download SBOM and signatures
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.sbom_artifact_name }}
-          path: sbom
+          path: dl
 
-      - name: Attach SBOM to release
+      - name: Attach to release
         uses: softprops/action-gh-release@v2
         with:
-          files: sbom/${{ needs.build.outputs.sbom_file_name }}
+          files: dl/*      # SBOM + .sigstore.json + .sig + .pem + .payload
+```
+
+**Verifying signatures**
+
+The keyless identity in the certificate is **this reusable workflow's ref**, not the caller repo.
+Verify with (using a regexp so it matches any branch/tag the workflow was pinned to):
+
+```bash
+ID_RE='^https://github.com/truefoundry/github-workflows-public/\.github/workflows/build\.yml@.*'
+ISSUER='https://token.actions.githubusercontent.com'
+
+# Image — pulls the signature from the registry (recommended)
+cosign verify --certificate-oidc-issuer "$ISSUER" --certificate-identity-regexp "$ID_RE" \
+  tfy.jfrog.io/tfy-images/mlfoundry-server@sha256:<digest>
+
+# SBOM bundle — offline, from the release asset
+cosign verify-blob --bundle mlfoundry-server-<tag>.spdx.json.sigstore.json \
+  --certificate-oidc-issuer "$ISSUER" --certificate-identity-regexp "$ID_RE" \
+  mlfoundry-server-<tag>.spdx.json
+
+# Raw image signature — offline, from the release assets
+cosign verify-blob --signature mlfoundry-server-<tag>.sig --certificate mlfoundry-server-<tag>.pem \
+  --certificate-oidc-issuer "$ISSUER" --certificate-identity-regexp "$ID_RE" \
+  mlfoundry-server-<tag>.payload
 ```
 
 **GHCR (GitHub Container Registry)**


### PR DESCRIPTION
Signed-off-by: Raman Tehlan <ramantehlan@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches supply-chain signing and OIDC-backed registry writes; misconfigured caller permissions or signing-only without SBOM could break or weaken release compliance expectations.
> 
> **Overview**
> Adds optional **keyless Sigstore signing** to the reusable `build.yml` workflow via a new `enable_sign` input, aimed at OpenSSF Signed-Releases–style release assets.
> 
> When enabled, the workflow installs cosign, signs the pushed image by digest in every enabled registry, and writes release files (`.sig`, `.pem`, `.payload`) under `release-artifacts/`. With `enable_sbom` also on, it signs the SPDX SBOM into a `.sigstore.json` bundle. SBOM generation and the upload step are refactored so one artifact (`sbom_artifact_name`) holds the SBOM plus all signature files; upload runs when either SBOM or signing is enabled. New workflow outputs expose the signature file names for release jobs.
> 
> The README documents `enable_sign`, required caller `id-token: write`, updated release attachment examples, and `cosign verify` / `verify-blob` instructions (identity tied to this reusable workflow ref).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ce3483b2cc650d2334b4e4c8558067ea3b3bba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->